### PR TITLE
ci(deps): security hardening of third-party GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ The kubectl command / run  output.
 ## Example usage
 ```yaml
   - name: Configure AWS credentials
-    uses: aws-actions/configure-aws-credentials@v1
+    uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
     with:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       aws-region: ${{ env.region }}
 
   - name: List pods
-    uses: gkirok/aws-ssm-eks@v2
+    uses: gkirok/aws-ssm-eks@9c037ac58f2ac4ddfdc5d13333e98b0ff4f2e54d # v2
     env:
       CLUSTER_NAME: "my-cluster"
       BASTION_NAME: "my-bastion"
@@ -78,7 +78,7 @@ The kubectl command / run  output.
 ### Set BASTION_ID
 ```yaml
   - name: List pods
-    uses: gkirok/aws-ssm-eks@v2
+    uses: gkirok/aws-ssm-eks@9c037ac58f2ac4ddfdc5d13333e98b0ff4f2e54d # v2
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This PR improves the security posture of this repository by pinning GitHub Actions to the full length commit SHA.

> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork.

[Ref](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

Pinning to a commit SHA  will help mitigate supply chain attacks in GitHub Actions (e.g. [tj-actions/changed-files supply chain attack](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)).
